### PR TITLE
Add author info for Sean Dae Houlihan

### DIFF
--- a/paper.md
+++ b/paper.md
@@ -51,9 +51,9 @@ authors:
 # - name: Michael Dayan  # 12 commits, issues: opened 0 participated in 0
 #   orcid: 
 #   affiliation:  # add full names if not yet listed, or indexes if already are
-# - name: Dae Houlihan  # 12 commits, issues: opened 0 participated in 0
-#   orcid: 
-#   affiliation:  # add full names if not yet listed, or indexes if already are
+ - name: Sean Dae Houlihan  # 12 commits, issues: opened 0 participated in 0 # First: Sean Dae; Last: Houlihan
+   orcid: 0000-0001-5003-9278
+   affiliation:  1, Department of Brain and Cognitive Sciences, Massachusetts Institute of Technology
 # - name: Steven Tilley  # 11 commits, issues: opened 1 participated in 0
 #   orcid: 
 #   affiliation:  # add full names if not yet listed, or indexes if already are


### PR DESCRIPTION
First name: Sean Dae
Last name: Houlihan
ORCID: 0000-0001-5003-9278
Affiliation:
(a) PBS, Dartmouth
(b) BCS, MIT